### PR TITLE
docs: fix SKILL.md to match actual implementation

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fitbit-analytics
-description: Fitbit health and fitness data integration. Fetch steps, heart rate, sleep, activity, calories, and trends from Fitbit Web API. Generate automated health reports, correlations, and alerts for inactivity or abnormal metrics.
+description: Fitbit health and fitness data integration. Fetch steps, heart rate, sleep, activity, calories, and trends from Fitbit Web API. Generate automated health reports and alerts.
 ---
 
 # Fitbit Analytics
@@ -15,55 +15,65 @@ export FITBIT_ACCESS_TOKEN="your_access_token"
 export FITBIT_REFRESH_TOKEN="your_refresh_token"
 
 # Fetch daily steps
-python /home/art/.clawdbot/skills/fitbit-analytics/scripts/fitbit_api.py activity --days 7
+python scripts/fitbit_api.py steps --days 7
 
 # Get heart rate data
-python /home/art/.clawdbot/skills/fitbit-analytics/scripts/fitbit_api.py heartrate --days 7
+python scripts/fitbit_api.py heartrate --days 7
 
 # Sleep summary
-python /home/art/.clawdbot/skills/fitbit-analytics/scripts/fitbit_api.py sleep --days 7
+python scripts/fitbit_api.py sleep --days 7
 
 # Generate weekly health report
-python /home/art/.clawdbot/skills/fitbit-analytics/scripts/fitbit_api.py report --type weekly
+python scripts/fitbit_api.py report --type weekly
+
+# Get activity summary
+python scripts/fitbit_api.py summary --days 7
 ```
 
 ## When to Use
 
 Use this skill when:
-- Fetching Fitbit metrics (steps, calories, heart rate, sleep, activity)
+- Fetching Fitbit metrics (steps, calories, heart rate, sleep)
 - Analyzing activity trends over time
-- Correlating fitness data with sleep/productivity
 - Setting up alerts for inactivity or abnormal heart rate
-- Generating daily/weekly/monthly health reports
+- Generating daily/weekly health reports
 
 ## Core Workflows
 
-### 1. Data Fetching
+### 1. Data Fetching (CLI)
+```bash
+# Available commands:
+python scripts/fitbit_api.py steps --days 7
+python scripts/fitbit_api.py calories --days 7
+python scripts/fitbit_api.py heartrate --days 7
+python scripts/fitbit_api.py sleep --days 7
+python scripts/fitbit_api.py summary --days 7
+python scripts/fitbit_api.py report --type weekly
+```
+
+### 2. Data Fetching (Python API)
 ```python
 from fitbit_api import FitbitClient
 
-client = FitbitClient(
-    client_id=fitbit_client_id,
-    client_secret=fitbit_client_secret,
-    access_token=fitbit_access_token,
-    refresh_token=fitbit_refresh_token
-)
-steps_data = client.get_activity(start_date="2026-01-01", end_date="2026-01-16")
+client = FitbitClient()  # Uses env vars for credentials
+
+# Fetch data (requires start_date and end_date)
+steps_data = client.get_steps(start_date="2026-01-01", end_date="2026-01-16")
 hr_data = client.get_heartrate(start_date="2026-01-01", end_date="2026-01-16")
 sleep_data = client.get_sleep(start_date="2026-01-01", end_date="2026-01-16")
+activity_summary = client.get_activity_summary(start_date="2026-01-01", end_date="2026-01-16")
 ```
 
-### 2. Trend Analysis
+### 3. Analysis
 ```python
-from analyzer import FitbitAnalyzer
+from fitbit_api import FitbitAnalyzer
 
-analyzer = FitbitAnalyzer(steps_data, hr_data, sleep_data)
-avg_steps = analyzer.average_metric("steps")
-resting_hr = analyzer.average_metric("resting_heart_rate")
-sleep_score = analyzer.calculate_sleep_score()
+analyzer = FitbitAnalyzer(steps_data, hr_data)
+summary = analyzer.summary()
+# Returns: avg_steps, avg_resting_hr, step_trend
 ```
 
-### 3. Alerts
+### 4. Alerts
 ```python
 from alerts import FitbitAlerts
 
@@ -77,10 +87,22 @@ low_days = alerts.find_low_days(steps_data)
 
 ## Scripts
 
-- `scripts/fitbit_api.py` - Fitbit Web API wrapper
-- `scripts/analyzer.py` - Trend analysis and correlations
+- `scripts/fitbit_api.py` - Fitbit Web API wrapper, CLI, and analysis
 - `scripts/alerts.py` - Threshold-based notifications
-- `scripts/report.py` - Report generation
+
+## Available API Methods
+
+| Method | Description |
+|--------|-------------|
+| `get_steps(start, end)` | Daily step counts |
+| `get_calories(start, end)` | Daily calories burned |
+| `get_distance(start, end)` | Daily distance |
+| `get_activity_summary(start, end)` | Activity summary |
+| `get_heartrate(start, end)` | Heart rate data |
+| `get_sleep(start, end)` | Sleep data |
+| `get_sleep_stages(start, end)` | Detailed sleep stages |
+| `get_spo2(start, end)` | Blood oxygen levels |
+| `get_weight(start, end)` | Weight measurements |
 
 ## References
 


### PR DESCRIPTION
Fixes #1

## Changes
- Removed references to non-existent `scripts/analyzer.py` and `scripts/report.py`
- Fixed API method documentation (was `get_activity`, now correctly shows `get_activity_summary`)
- Fixed CLI examples to use correct commands (`steps` not `activity`)
- Added table of all available API methods
- Removed hardcoded paths (`/home/art/...`)
- Clarified what actually exists vs. what was aspirational