### PR TITLE
fix(auth): harden token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ python scripts/fitbit_briefing.py --format brief
 python scripts/fitbit_briefing.py --format json
 ```
 
+### Proactive Token Refresh
+```bash
+# Refresh only when the last token rotation is older than 6 hours
+python scripts/refresh_tokens.py
+
+# Force a refresh immediately
+python scripts/refresh_tokens.py --force
+```
+
 **Example brief output:**
 ```
 📊 8,543 steps • 2,340 cal
@@ -118,10 +127,24 @@ python scripts/fitbit_briefing.py --format json
 
 ## Structure
 - `scripts/fitbit_api.py`: Main API wrapper and CLI tool.
+- `scripts/refresh_tokens.py`: Standalone proactive token refresh CLI.
 - `scripts/fitbit_briefing.py`: Morning briefing CLI (text/brief/json output).
 - `scripts/alerts.py`: Threshold-based notifications.
 - `references/`: API and metrics documentation.
 - `docs/`: Privacy Policy and Terms of Service.
+
+## Token Refresh Behavior
+- The client refreshes tokens proactively before API calls when the access token is close to expiry.
+- A 401 response still triggers one forced refresh/retry to cover stale expiry metadata or clock drift.
+- Successful refreshes update `~/.config/systemd/user/secrets.conf` when present and always rewrite `~/.fitbit-analytics/tokens.json` atomically.
+- The token cache now stores both `expires_at` and `refreshed_at` so `scripts/refresh_tokens.py` can rotate refresh tokens before Fitbit inactivity limits are hit.
+
+## Automation
+Run the standalone refresh command every 6 hours to keep the rotated refresh token active:
+
+```bash
+0 */6 * * * cd /path/to/fitbit-analytics-openclaw-skill && python3 scripts/refresh_tokens.py
+```
 
 ## License
 Apache 2.0

--- a/SETUP.md
+++ b/SETUP.md
@@ -54,7 +54,26 @@ FITBIT_REFRESH_TOKEN="x8z..."
 ```
 
 ## 6. Run
-The skill is now ready. The script will automatically refresh the token when it expires.
+The skill is now ready. The client refreshes access tokens proactively before expiry and rewrites persisted tokens atomically after a successful rotation.
 ```bash
 python scripts/fitbit_api.py report --type weekly
 ```
+
+## 7. Keep Refresh Tokens Active
+Run the standalone refresh command every 6 hours so Fitbit refresh token rotation stays ahead of inactivity expiry:
+
+```bash
+python scripts/refresh_tokens.py
+```
+
+Example cron entry:
+
+```bash
+0 */6 * * * cd /path/to/fitbit-analytics-openclaw-skill && python3 scripts/refresh_tokens.py
+```
+
+The local cache file `~/.fitbit-analytics/tokens.json` now stores:
+- `access_token`
+- `refresh_token`
+- `expires_at`
+- `refreshed_at`

--- a/SKILL.md
+++ b/SKILL.md
@@ -30,6 +30,9 @@ python scripts/fitbit_api.py sleep --days 7
 # Generate weekly health report
 python scripts/fitbit_api.py report --type weekly
 
+# Refresh rotated OAuth tokens when due
+python scripts/refresh_tokens.py
+
 # Get activity summary
 python scripts/fitbit_api.py summary --days 7
 ```
@@ -135,6 +138,7 @@ python {baseDir}/scripts/alerts.py --days 7 --steps 8000 --sleep 7
 ## Scripts
 
 - `scripts/fitbit_api.py` - Fitbit Web API wrapper, CLI, and analysis
+- `scripts/refresh_tokens.py` - Standalone proactive token refresh CLI
 - `scripts/fitbit_briefing.py` - Morning briefing CLI (text/brief/json output)
 - `scripts/alerts.py` - Threshold-based notifications
 
@@ -165,6 +169,7 @@ Fitbit API requires OAuth 2.0 authentication:
 2. Get client_id and client_secret
 3. Complete OAuth flow to get access_token and refresh_token
 4. Set environment variables or pass to scripts
+5. Run `python scripts/refresh_tokens.py` every 6 hours to keep refresh token rotation active
 
 ## Environment
 
@@ -193,3 +198,19 @@ openclaw cron add \
 ```
 
 **Note:** Replace `/path/to/your/` with your actual path and `<YOUR_TELEGRAM_CHAT_ID>` with your Telegram channel/group ID.
+
+### Proactive Token Refresh (Every 6 Hours)
+```bash
+openclaw cron add \
+  --name "Refresh Fitbit Tokens" \
+  --cron "0 */6 * * *" \
+  --tz "America/Los_Angeles" \
+  --session isolated \
+  --wake next-heartbeat \
+  --deliver \
+  --channel telegram \
+  --target "<YOUR_TELEGRAM_CHAT_ID>" \
+  --message "cd /path/to/your && python3 scripts/refresh_tokens.py"
+```
+
+The token cache at `~/.fitbit-analytics/tokens.json` stores `expires_at` and `refreshed_at` so the refresh command can rotate tokens before Fitbit inactivity expiry.

--- a/scripts/fitbit_api.py
+++ b/scripts/fitbit_api.py
@@ -75,8 +75,10 @@ class FitbitClient:
         """Load a value from secrets.conf."""
         if SECRETS_PATH.exists():
             for line in SECRETS_PATH.read_text().split('\n'):
-                if '=' in line and key in line:
-                    return line.split('=', 1)[1].strip().strip('"')
+                parsed_key, parsed_value, _ = self._parse_secret_assignment(line)
+                if parsed_key == key:
+                    value = parsed_value.strip().strip('"')
+                    return value or None
         return None
 
     def _resolve_value(self, explicit_value, key):
@@ -85,11 +87,11 @@ class FitbitClient:
             return explicit_value, "explicit"
 
         env_value = os.environ.get(key)
-        if env_value is not None:
+        if env_value:
             return env_value, "env"
 
         secret_value = self._load_secret_value(key)
-        if secret_value is not None:
+        if secret_value:
             return secret_value, "secrets"
 
         return None, None
@@ -238,8 +240,9 @@ class FitbitClient:
         assignment = f'{key}="{value}"'
         lines = content.splitlines()
         for index, line in enumerate(lines):
-            if line.startswith(f"{key}="):
-                lines[index] = assignment
+            parsed_key, _, prefix = self._parse_secret_assignment(line)
+            if parsed_key == key:
+                lines[index] = f'{prefix}{assignment}'
                 break
         else:
             lines.append(assignment)
@@ -248,6 +251,23 @@ class FitbitClient:
         if content.endswith("\n") or not content:
             updated += "\n"
         return updated
+
+    def _parse_secret_assignment(self, line):
+        """Parse a secrets.conf assignment and preserve export prefix."""
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            return None, None, ""
+
+        prefix = ""
+        if stripped.startswith("export "):
+            prefix = "export "
+            stripped = stripped[len("export "):].lstrip()
+
+        key, separator, value = stripped.partition("=")
+        if separator != "=":
+            return None, None, prefix
+
+        return key.strip(), value.strip(), prefix
 
     def _mask_token(self, value):
         """Return a short fingerprint for audit logs without exposing secrets."""

--- a/scripts/fitbit_api.py
+++ b/scripts/fitbit_api.py
@@ -14,16 +14,30 @@ import sys
 import json
 import argparse
 import base64
+import fcntl
+import hashlib
 import stat
+import tempfile
+import time
 import urllib.request
 import urllib.error
 import urllib.parse
 from datetime import datetime, timedelta
 from pathlib import Path
+from contextlib import contextmanager
 
 SKILL_DIR = Path(__file__).parent.parent
 SECRETS_PATH = Path.home() / ".config" / "systemd" / "user" / "secrets.conf"
 TOKEN_CACHE_PATH = Path.home() / ".fitbit-analytics" / "tokens.json"
+TOKEN_LOCK_PATH = Path.home() / ".fitbit-analytics" / "tokens.lock"
+
+
+class FitbitAuthError(RuntimeError):
+    """Base error for Fitbit authentication failures."""
+
+
+class FitbitReauthRequiredError(FitbitAuthError):
+    """Raised when Fitbit requires a new OAuth authorization flow."""
 
 
 class FitbitClient:
@@ -31,14 +45,19 @@ class FitbitClient:
 
     BASE_URL = "https://api.fitbit.com"
     TOKEN_REFRESH_THRESHOLD_HOURS = 1  # Refresh if expires within 1 hour
+    REFRESH_MAX_AGE_HOURS = 6
+    REFRESH_RETRY_DELAYS_SECONDS = (1, 2, 4)
 
     def __init__(self, client_id=None, client_secret=None, access_token=None, refresh_token=None):
         self.client_id = client_id or self._load_env_from_secrets("FITBIT_CLIENT_ID")
         self.client_secret = client_secret or self._load_env_from_secrets("FITBIT_CLIENT_SECRET")
+        self._explicit_access_token = access_token is not None
+        self._explicit_refresh_token = refresh_token is not None
         self._access_token = access_token or self._load_env_from_secrets("FITBIT_ACCESS_TOKEN")
         self._refresh_token = refresh_token or self._load_env_from_secrets("FITBIT_REFRESH_TOKEN")
         self._token_expires_at = None
-        self._load_token_expiry()
+        self._token_refreshed_at = None
+        self._load_token_metadata()
 
         if not self._access_token:
             raise ValueError("FITBIT_ACCESS_TOKEN not set. Get tokens via OAuth flow.")
@@ -58,21 +77,48 @@ class FitbitClient:
                     return line.split('=', 1)[1].strip().strip('"')
         return None
 
-    def _load_token_expiry(self):
-        """Load token expiry from cache file or JWT decode"""
-        if TOKEN_CACHE_PATH.exists():
-            try:
-                data = json.loads(TOKEN_CACHE_PATH.read_text())
-                expires_at = data.get("expires_at")
-                if expires_at:
-                    self._token_expires_at = datetime.fromisoformat(expires_at)
-                    return
-            except (json.JSONDecodeError, KeyError):
-                pass
+    def _load_token_metadata(self):
+        """Load token metadata from cache file or JWT decode."""
+        self._load_cached_tokens()
 
-        # Fallback: decode from JWT
-        if self._access_token:
+        if not self._token_expires_at and self._access_token:
             self._decode_jwt_expiry()
+
+    def _load_cached_tokens(self, allow_override=False):
+        """Load the latest persisted tokens and timestamps from cache."""
+        if not TOKEN_CACHE_PATH.exists():
+            return False
+
+        try:
+            data = json.loads(TOKEN_CACHE_PATH.read_text())
+        except (json.JSONDecodeError, OSError):
+            return False
+
+        access_token = data.get("access_token")
+        refresh_token = data.get("refresh_token")
+        expires_at = data.get("expires_at")
+        refreshed_at = data.get("refreshed_at")
+
+        if access_token and (allow_override or not self._explicit_access_token):
+            self._access_token = access_token
+        if refresh_token and (allow_override or not self._explicit_refresh_token):
+            self._refresh_token = refresh_token
+        if expires_at:
+            try:
+                self._token_expires_at = datetime.fromisoformat(expires_at)
+            except ValueError:
+                self._token_expires_at = None
+        if refreshed_at:
+            try:
+                self._token_refreshed_at = datetime.fromisoformat(refreshed_at)
+            except ValueError:
+                self._token_refreshed_at = None
+        if self._access_token:
+            self.headers = {
+                "Authorization": f"Bearer {self._access_token}",
+                "Content-Type": "application/json"
+            }
+        return True
 
     def _decode_jwt_expiry(self):
         """Decode access token JWT to get expiry timestamp"""
@@ -95,11 +141,82 @@ class FitbitClient:
         threshold = datetime.now() + timedelta(hours=self.TOKEN_REFRESH_THRESHOLD_HOURS)
         return self._token_expires_at < threshold
 
+    def _is_refresh_age_exceeded(self, max_age_hours):
+        """Check if refresh token rotation age exceeds the desired max age."""
+        if not self._token_refreshed_at:
+            return True
+        age_limit = datetime.now() - timedelta(hours=max_age_hours)
+        return self._token_refreshed_at < age_limit
+
+    def _should_refresh_for_rotation(self, max_age_hours):
+        """Check if token refresh is due for expiry or rotation age."""
+        return self._should_refresh() or self._is_refresh_age_exceeded(max_age_hours)
+
+    @contextmanager
+    def _token_lock(self):
+        """Serialize token refresh and persistence across processes."""
+        TOKEN_LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with TOKEN_LOCK_PATH.open("a+", encoding="utf-8") as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def _atomic_write_text(self, path, content):
+        """Write file contents atomically with secure permissions."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, temp_path = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(temp_path, stat.S_IRUSR | stat.S_IWUSR)
+            os.replace(temp_path, path)
+        finally:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+
+    def _upsert_secret(self, content, key, value):
+        """Insert or replace a quoted env assignment without regex substitution."""
+        assignment = f'{key}="{value}"'
+        lines = content.splitlines()
+        for index, line in enumerate(lines):
+            if line.startswith(f"{key}="):
+                lines[index] = assignment
+                break
+        else:
+            lines.append(assignment)
+
+        updated = "\n".join(lines)
+        if content.endswith("\n") or not content:
+            updated += "\n"
+        return updated
+
+    def _mask_token(self, value):
+        """Return a short fingerprint for audit logs without exposing secrets."""
+        if not value:
+            return "missing"
+        return hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+
+    def _log_token_rotation(self):
+        """Write a masked audit message for successful token rotation."""
+        refreshed_at = self._token_refreshed_at.isoformat() if self._token_refreshed_at else "unknown"
+        access_fingerprint = self._mask_token(self._access_token)
+        refresh_fingerprint = self._mask_token(self._refresh_token)
+        print(
+            f"Rotated Fitbit tokens at {refreshed_at} "
+            f"(access={access_fingerprint}, refresh={refresh_fingerprint})",
+            file=sys.stderr,
+        )
+
     def _save_tokens(self, access_token, refresh_token, expires_in):
         """Save tokens to secrets.conf and cache file"""
         self._access_token = access_token
         self._refresh_token = refresh_token
-        self._token_expires_at = datetime.now() + timedelta(seconds=expires_in)
+        self._token_refreshed_at = datetime.now()
+        self._token_expires_at = self._token_refreshed_at + timedelta(seconds=expires_in)
 
         # Update secrets.conf
         if SECRETS_PATH.exists():
@@ -109,26 +226,109 @@ class FitbitClient:
                 "FITBIT_REFRESH_TOKEN": refresh_token
             }
             for key, value in updates.items():
-                if f'{key}="' in content:
-                    import re
-                    pattern = rf'({key}=")([^"]*)(")'
-                    content = re.sub(pattern, rf'\1{value}\3', content)
-                else:
-                    content += f'\n{key}="{value}"'
-            SECRETS_PATH.write_text(content)
-            os.chmod(str(SECRETS_PATH), stat.S_IRUSR | stat.S_IWUSR)
+                content = self._upsert_secret(content, key, value)
+            self._atomic_write_text(SECRETS_PATH, content)
 
         # Save to cache file
-        TOKEN_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
-        TOKEN_CACHE_PATH.write_text(json.dumps({
+        cache_payload = json.dumps({
             "access_token": access_token,
             "refresh_token": refresh_token,
-            "expires_at": self._token_expires_at.isoformat()
-        }, indent=2))
-        os.chmod(str(TOKEN_CACHE_PATH), stat.S_IRUSR | stat.S_IWUSR)
+            "expires_at": self._token_expires_at.isoformat(),
+            "refreshed_at": self._token_refreshed_at.isoformat()
+        }, indent=2)
+        self._atomic_write_text(TOKEN_CACHE_PATH, cache_payload)
+        self.headers["Authorization"] = f"Bearer {self._access_token}"
 
-    def _request(self, endpoint, date_type="date"):
+    def _parse_http_error(self, error):
+        """Extract Fitbit error type and message from an HTTPError body."""
+        try:
+            payload = error.read().decode("utf-8")
+        except Exception:
+            return None, None
+
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            return None, payload or None
+
+        errors = data.get("errors")
+        if isinstance(errors, list) and errors:
+            error_item = errors[0]
+            return error_item.get("errorType"), error_item.get("message")
+        return None, payload or None
+
+    def refresh_access_token(self, force=False, max_age_hours=None):
+        """Refresh access token when due or when forced."""
+        with self._token_lock():
+            self._load_cached_tokens(allow_override=True)
+
+            if not force:
+                if max_age_hours is None:
+                    if not self._should_refresh():
+                        return False
+                elif not self._should_refresh_for_rotation(max_age_hours):
+                    return False
+
+            if not self.client_id or not self.client_secret or not self._refresh_token:
+                raise FitbitAuthError("Fitbit credentials or refresh token are missing.")
+
+            auth_b64 = base64.b64encode(f"{self.client_id}:{self.client_secret}".encode()).decode()
+            data = urllib.parse.urlencode({
+                "grant_type": "refresh_token",
+                "refresh_token": self._refresh_token
+            }).encode()
+
+            req = urllib.request.Request(
+                "https://api.fitbit.com/oauth2/token",
+                data=data,
+                headers={
+                    "Authorization": f"Basic {auth_b64}",
+                    "Content-Type": "application/x-www-form-urlencoded"
+                },
+                method="POST"
+            )
+
+            for attempt, delay in enumerate(self.REFRESH_RETRY_DELAYS_SECONDS, start=1):
+                try:
+                    with urllib.request.urlopen(req, timeout=10) as resp:
+                        tokens = json.loads(resp.read().decode("utf-8"))
+                    access_token = tokens.get("access_token")
+                    refresh_token = tokens.get("refresh_token")
+                    expires_in = tokens.get("expires_in", 28800)
+                    if not access_token or not refresh_token:
+                        raise FitbitAuthError("Fitbit refresh response did not include rotated tokens.")
+
+                    self._save_tokens(access_token, refresh_token, expires_in)
+                    self._log_token_rotation()
+                    return True
+                except urllib.error.HTTPError as error:
+                    error_type, error_message = self._parse_http_error(error)
+                    if error.code == 400 and error_type == "invalid_grant":
+                        raise FitbitReauthRequiredError(
+                            "Fitbit refresh token is invalid; re-authorization is required."
+                        ) from error
+                    if error.code in (429, 500, 502, 503, 504) and attempt < len(self.REFRESH_RETRY_DELAYS_SECONDS):
+                        time.sleep(delay)
+                        continue
+                    detail = error_message or error.reason
+                    raise FitbitAuthError(
+                        f"Fitbit token refresh failed: HTTP {error.code} {detail}"
+                    ) from error
+                except urllib.error.URLError as error:
+                    if attempt < len(self.REFRESH_RETRY_DELAYS_SECONDS):
+                        time.sleep(delay)
+                        continue
+                    raise FitbitAuthError(
+                        f"Fitbit token refresh failed after retries: {error.reason}"
+                    ) from error
+
+            raise FitbitAuthError("Fitbit token refresh failed after retries.")
+
+    def _request(self, endpoint, date_type="date", allow_retry=True):
         """Make API request with auto-refresh"""
+        if self._should_refresh():
+            self.refresh_access_token()
+
         url = f"{self.BASE_URL}/{endpoint}"
         req = urllib.request.Request(url, headers=self.headers)
 
@@ -136,45 +336,10 @@ class FitbitClient:
             with urllib.request.urlopen(req, timeout=10) as resp:
                 return json.loads(resp.read().decode("utf-8"))
         except urllib.error.HTTPError as e:
-            if e.code == 401 and self._should_refresh():
-                if self._refresh_access_token():
-                    return self._request(endpoint, date_type)
+            if e.code == 401 and allow_retry:
+                self.refresh_access_token(force=True)
+                return self._request(endpoint, date_type, allow_retry=False)
             raise
-
-    def _refresh_access_token(self):
-        """Refresh access token and persist"""
-        if not self.client_id or not self.client_secret or not self._refresh_token:
-            return False
-
-        auth_b64 = base64.b64encode(f"{self.client_id}:{self.client_secret}".encode()).decode()
-        data = urllib.parse.urlencode({
-            "grant_type": "refresh_token",
-            "refresh_token": self._refresh_token
-        }).encode()
-
-        req = urllib.request.Request(
-            "https://api.fitbit.com/oauth2/token",
-            data=data,
-            headers={
-                "Authorization": f"Basic {auth_b64}",
-                "Content-Type": "application/x-www-form-urlencoded"
-            },
-            method="POST"
-        )
-
-        try:
-            with urllib.request.urlopen(req, timeout=10) as resp:
-                tokens = json.loads(resp.read().decode("utf-8"))
-                access_token = tokens.get("access_token")
-                refresh_token = tokens.get("refresh_token")
-                expires_in = tokens.get("expires_in", 28800)
-
-                self._save_tokens(access_token, refresh_token, expires_in)
-                self.headers["Authorization"] = f"Bearer {self._access_token}"
-                return True
-        except urllib.error.HTTPError as e:
-            print(f"Token refresh failed: {e.code} {e.reason}", file=sys.stderr)
-            return False
 
     def get_steps(self, start_date, end_date):
         """Fetch step data"""

--- a/scripts/fitbit_api.py
+++ b/scripts/fitbit_api.py
@@ -383,7 +383,10 @@ class FitbitClient:
     def _request(self, endpoint, date_type="date", allow_retry=True):
         """Make API request with auto-refresh"""
         if self._should_refresh() and self._can_refresh_access_token():
-            self.refresh_access_token()
+            try:
+                self.refresh_access_token()
+            except FitbitAuthError as error:
+                print(f"Fitbit preflight refresh skipped: {error}", file=sys.stderr)
 
         url = f"{self.BASE_URL}/{endpoint}"
         req = urllib.request.Request(url, headers=self.headers)

--- a/scripts/fitbit_api.py
+++ b/scripts/fitbit_api.py
@@ -203,6 +203,10 @@ class FitbitClient:
         """Check if token refresh is due for expiry or rotation age."""
         return self._should_refresh() or self._is_refresh_age_exceeded(max_age_hours)
 
+    def _can_refresh_access_token(self):
+        """Check whether refresh credentials are available."""
+        return bool(self.client_id and self.client_secret and self._refresh_token)
+
     @contextmanager
     def _token_lock(self):
         """Serialize token refresh and persistence across processes."""
@@ -321,7 +325,7 @@ class FitbitClient:
                 elif not self._should_refresh_for_rotation(max_age_hours):
                     return False
 
-            if not self.client_id or not self.client_secret or not self._refresh_token:
+            if not self._can_refresh_access_token():
                 raise FitbitAuthError("Fitbit credentials or refresh token are missing.")
 
             auth_b64 = base64.b64encode(f"{self.client_id}:{self.client_secret}".encode()).decode()
@@ -378,7 +382,7 @@ class FitbitClient:
 
     def _request(self, endpoint, date_type="date", allow_retry=True):
         """Make API request with auto-refresh"""
-        if self._should_refresh():
+        if self._should_refresh() and self._can_refresh_access_token():
             self.refresh_access_token()
 
         url = f"{self.BASE_URL}/{endpoint}"
@@ -388,7 +392,7 @@ class FitbitClient:
             with urllib.request.urlopen(req, timeout=10) as resp:
                 return json.loads(resp.read().decode("utf-8"))
         except urllib.error.HTTPError as e:
-            if e.code == 401 and allow_retry:
+            if e.code == 401 and allow_retry and self._can_refresh_access_token():
                 self.refresh_access_token(force=True)
                 return self._request(endpoint, date_type, allow_retry=False)
             raise

--- a/scripts/fitbit_api.py
+++ b/scripts/fitbit_api.py
@@ -49,12 +49,10 @@ class FitbitClient:
     REFRESH_RETRY_DELAYS_SECONDS = (1, 2, 4)
 
     def __init__(self, client_id=None, client_secret=None, access_token=None, refresh_token=None):
-        self.client_id = client_id or self._load_env_from_secrets("FITBIT_CLIENT_ID")
-        self.client_secret = client_secret or self._load_env_from_secrets("FITBIT_CLIENT_SECRET")
-        self._explicit_access_token = access_token is not None
-        self._explicit_refresh_token = refresh_token is not None
-        self._access_token = access_token or self._load_env_from_secrets("FITBIT_ACCESS_TOKEN")
-        self._refresh_token = refresh_token or self._load_env_from_secrets("FITBIT_REFRESH_TOKEN")
+        self.client_id, _ = self._resolve_value(client_id, "FITBIT_CLIENT_ID")
+        self.client_secret, _ = self._resolve_value(client_secret, "FITBIT_CLIENT_SECRET")
+        self._access_token, self._access_token_source = self._resolve_value(access_token, "FITBIT_ACCESS_TOKEN")
+        self._refresh_token, self._refresh_token_source = self._resolve_value(refresh_token, "FITBIT_REFRESH_TOKEN")
         self._token_expires_at = None
         self._token_refreshed_at = None
         self._load_token_metadata()
@@ -71,11 +69,30 @@ class FitbitClient:
         """Load env var from secrets.conf if not already set"""
         if os.environ.get(key):
             return os.environ[key]
+        return self._load_secret_value(key)
+
+    def _load_secret_value(self, key):
+        """Load a value from secrets.conf."""
         if SECRETS_PATH.exists():
             for line in SECRETS_PATH.read_text().split('\n'):
                 if '=' in line and key in line:
                     return line.split('=', 1)[1].strip().strip('"')
         return None
+
+    def _resolve_value(self, explicit_value, key):
+        """Resolve config value and record its source precedence."""
+        if explicit_value is not None:
+            return explicit_value, "explicit"
+
+        env_value = os.environ.get(key)
+        if env_value is not None:
+            return env_value, "env"
+
+        secret_value = self._load_secret_value(key)
+        if secret_value is not None:
+            return secret_value, "secrets"
+
+        return None, None
 
     def _load_token_metadata(self):
         """Load token metadata from cache file or JWT decode."""
@@ -99,10 +116,12 @@ class FitbitClient:
         expires_at = data.get("expires_at")
         refreshed_at = data.get("refreshed_at")
 
-        if access_token and (allow_override or not self._explicit_access_token):
+        if access_token and self._can_use_cached_token(self._access_token_source, allow_override):
             self._access_token = access_token
-        if refresh_token and (allow_override or not self._explicit_refresh_token):
+            self._access_token_source = "cache"
+        if refresh_token and self._can_use_cached_token(self._refresh_token_source, allow_override):
             self._refresh_token = refresh_token
+            self._refresh_token_source = "cache"
         if expires_at:
             try:
                 self._token_expires_at = datetime.fromisoformat(expires_at)
@@ -119,6 +138,38 @@ class FitbitClient:
                 "Content-Type": "application/json"
             }
         return True
+
+    def _can_use_cached_token(self, token_source, allow_override):
+        """Determine whether cached token values may replace the current source."""
+        if token_source in ("explicit", "env", "secrets"):
+            return False
+        return allow_override or token_source in (None, "cache")
+
+    def _reload_authoritative_tokens(self):
+        """Reload tokens from their authoritative source before refresh under lock."""
+        if self._access_token_source == "env":
+            latest_access = os.environ.get("FITBIT_ACCESS_TOKEN")
+            if latest_access:
+                self._access_token = latest_access
+        elif self._access_token_source == "secrets":
+            latest_access = self._load_secret_value("FITBIT_ACCESS_TOKEN")
+            if latest_access:
+                self._access_token = latest_access
+
+        if self._refresh_token_source == "env":
+            latest_refresh = os.environ.get("FITBIT_REFRESH_TOKEN")
+            if latest_refresh:
+                self._refresh_token = latest_refresh
+        elif self._refresh_token_source == "secrets":
+            latest_refresh = self._load_secret_value("FITBIT_REFRESH_TOKEN")
+            if latest_refresh:
+                self._refresh_token = latest_refresh
+
+        if self._access_token:
+            self.headers = {
+                "Authorization": f"Bearer {self._access_token}",
+                "Content-Type": "application/json"
+            }
 
     def _decode_jwt_expiry(self):
         """Decode access token JWT to get expiry timestamp"""
@@ -260,7 +311,8 @@ class FitbitClient:
     def refresh_access_token(self, force=False, max_age_hours=None):
         """Refresh access token when due or when forced."""
         with self._token_lock():
-            self._load_cached_tokens(allow_override=True)
+            self._reload_authoritative_tokens()
+            self._load_cached_tokens(allow_override=False)
 
             if not force:
                 if max_age_hours is None:

--- a/scripts/refresh_tokens.py
+++ b/scripts/refresh_tokens.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Standalone Fitbit token refresh command.
+
+Usage:
+    python refresh_tokens.py
+    python refresh_tokens.py --force
+    python refresh_tokens.py --max-age-hours 6
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from fitbit_api import FitbitAuthError
+from fitbit_api import FitbitClient
+from fitbit_api import FitbitReauthRequiredError
+
+DEFAULT_MAX_AGE_HOURS = FitbitClient.REFRESH_MAX_AGE_HOURS
+
+
+def main(argv=None):
+    """Refresh Fitbit tokens when due or when forced."""
+    parser = argparse.ArgumentParser(description="Refresh Fitbit OAuth tokens")
+    parser.add_argument("--force", action="store_true", help="Refresh immediately even if tokens are current")
+    parser.add_argument(
+        "--max-age-hours",
+        type=int,
+        default=DEFAULT_MAX_AGE_HOURS,
+        help="Refresh when the last successful rotation is older than this many hours",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        client = FitbitClient()
+        refreshed = client.refresh_access_token(
+            force=args.force,
+            max_age_hours=args.max_age_hours,
+        )
+    except ValueError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except FitbitReauthRequiredError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+    except FitbitAuthError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    if refreshed:
+        print("Fitbit tokens refreshed.", file=sys.stderr)
+    else:
+        print("Fitbit tokens are current; refresh skipped.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_fitbit_auth.py
+++ b/tests/test_fitbit_auth.py
@@ -6,6 +6,7 @@ import threading
 import time as pytime
 import unittest
 import urllib.error
+import urllib.parse
 from contextlib import redirect_stderr
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -88,6 +89,24 @@ class FitbitAuthTests(unittest.TestCase):
         self.assertEqual(cache_data["refresh_token"], "456refresh")
         self.assertIn("refreshed_at", cache_data)
 
+    def test_client_prefers_secrets_file_tokens_over_stale_cache(self):
+        self.cache_path.write_text(
+            json.dumps(
+                {
+                    "access_token": "stale_cache_access",
+                    "refresh_token": "stale_cache_refresh",
+                    "expires_at": (datetime.now() + timedelta(hours=1)).isoformat(),
+                    "refreshed_at": datetime.now().isoformat(),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        client = self.make_client()
+
+        self.assertEqual(client._access_token, "old_access")
+        self.assertEqual(client._refresh_token, "old_refresh")
+
     def test_request_refreshes_before_api_call_when_token_is_near_expiry(self):
         client = self.make_client()
         client._token_expires_at = datetime.now() + timedelta(minutes=30)
@@ -169,6 +188,43 @@ class FitbitAuthTests(unittest.TestCase):
         self.assertEqual(sleep_mock.call_count, len(client.REFRESH_RETRY_DELAYS_SECONDS) - 1)
         self.assertEqual(self.secrets_path.read_text(encoding="utf-8"), before_secrets)
         self.assertEqual(self.cache_path.read_text(encoding="utf-8"), before_cache)
+
+    def test_refresh_access_token_uses_explicit_refresh_token_instead_of_cache(self):
+        self.cache_path.write_text(
+            json.dumps(
+                {
+                    "access_token": "cache_access",
+                    "refresh_token": "cache_refresh",
+                    "expires_at": (datetime.now() + timedelta(hours=1)).isoformat(),
+                    "refreshed_at": datetime.now().isoformat(),
+                }
+            ),
+            encoding="utf-8",
+        )
+        client = fitbit_api.FitbitClient(
+            client_id="client",
+            client_secret="secret",
+            access_token="explicit_access",
+            refresh_token="explicit_refresh",
+        )
+
+        def fake_urlopen(req, timeout=10):
+            request_payload = urllib.parse.parse_qs(req.data.decode("utf-8"))
+            self.assertEqual(request_payload["refresh_token"], ["explicit_refresh"])
+            return FakeResponse(
+                {
+                    "access_token": "rotated_access",
+                    "refresh_token": "rotated_refresh",
+                    "expires_in": 3600,
+                }
+            )
+
+        with mock.patch.object(fitbit_api.urllib.request, "urlopen", side_effect=fake_urlopen):
+            refreshed = client.refresh_access_token(force=True)
+
+        self.assertTrue(refreshed)
+        self.assertEqual(client._access_token, "rotated_access")
+        self.assertEqual(client._refresh_token, "rotated_refresh")
 
     def test_refresh_access_token_waits_for_lock_before_refreshing(self):
         client = self.make_client()

--- a/tests/test_fitbit_auth.py
+++ b/tests/test_fitbit_auth.py
@@ -128,6 +128,21 @@ class FitbitAuthTests(unittest.TestCase):
         self.assertEqual(events, ["refresh", "request"])
         refresh_mock.assert_called_once_with()
 
+    def test_request_skips_preflight_refresh_when_refresh_credentials_are_missing(self):
+        client = fitbit_api.FitbitClient(access_token="token_only_access")
+        client._token_expires_at = None
+
+        with mock.patch.object(client, "refresh_access_token") as refresh_mock:
+            with mock.patch.object(
+                fitbit_api.urllib.request,
+                "urlopen",
+                return_value=FakeResponse({"ok": True}),
+            ):
+                response = client._request("1/user/-/profile.json")
+
+        self.assertEqual(response, {"ok": True})
+        refresh_mock.assert_not_called()
+
     def test_request_retries_once_on_401_with_stale_metadata(self):
         client = self.make_client()
         client._token_expires_at = datetime.now() + timedelta(hours=4)

--- a/tests/test_fitbit_auth.py
+++ b/tests/test_fitbit_auth.py
@@ -1,0 +1,241 @@
+import io
+import json
+import sys
+import tempfile
+import threading
+import time as pytime
+import unittest
+import urllib.error
+from contextlib import redirect_stderr
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import fitbit_api
+import refresh_tokens
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+class FitbitAuthTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.temp_path = Path(self.tempdir.name)
+        self.secrets_path = self.temp_path / "secrets.conf"
+        self.cache_path = self.temp_path / "tokens.json"
+        self.lock_path = self.temp_path / "tokens.lock"
+        self.secrets_path.write_text(
+            'FITBIT_ACCESS_TOKEN="old_access"\nFITBIT_REFRESH_TOKEN="old_refresh"\n',
+            encoding="utf-8",
+        )
+
+        self.patches = [
+            mock.patch.object(fitbit_api, "SECRETS_PATH", self.secrets_path),
+            mock.patch.object(fitbit_api, "TOKEN_CACHE_PATH", self.cache_path),
+            mock.patch.object(fitbit_api, "TOKEN_LOCK_PATH", self.lock_path),
+        ]
+        for patcher in self.patches:
+            patcher.start()
+
+    def tearDown(self):
+        for patcher in reversed(self.patches):
+            patcher.stop()
+        self.tempdir.cleanup()
+
+    def make_client(self):
+        return fitbit_api.FitbitClient(client_id="client", client_secret="secret")
+
+    def http_error(self, code, reason, payload=None):
+        body = b""
+        if payload is not None:
+            body = json.dumps(payload).encode("utf-8")
+        return urllib.error.HTTPError(
+            url="https://api.fitbit.com/oauth2/token",
+            code=code,
+            msg=reason,
+            hdrs=None,
+            fp=io.BytesIO(body),
+        )
+
+    def test_save_tokens_persists_digit_prefixed_values(self):
+        client = self.make_client()
+
+        client._save_tokens("123access", "456refresh", 3600)
+
+        secrets_content = self.secrets_path.read_text(encoding="utf-8")
+        self.assertIn('FITBIT_ACCESS_TOKEN="123access"', secrets_content)
+        self.assertIn('FITBIT_REFRESH_TOKEN="456refresh"', secrets_content)
+
+        cache_data = json.loads(self.cache_path.read_text(encoding="utf-8"))
+        self.assertEqual(cache_data["access_token"], "123access")
+        self.assertEqual(cache_data["refresh_token"], "456refresh")
+        self.assertIn("refreshed_at", cache_data)
+
+    def test_request_refreshes_before_api_call_when_token_is_near_expiry(self):
+        client = self.make_client()
+        client._token_expires_at = datetime.now() + timedelta(minutes=30)
+        events = []
+
+        def fake_refresh(*args, **kwargs):
+            events.append("refresh")
+            return True
+
+        def fake_urlopen(req, timeout=10):
+            events.append("request")
+            return FakeResponse({"ok": True})
+
+        with mock.patch.object(client, "refresh_access_token", side_effect=fake_refresh) as refresh_mock:
+            with mock.patch.object(fitbit_api.urllib.request, "urlopen", side_effect=fake_urlopen):
+                response = client._request("1/user/-/profile.json")
+
+        self.assertEqual(response, {"ok": True})
+        self.assertEqual(events, ["refresh", "request"])
+        refresh_mock.assert_called_once_with()
+
+    def test_request_retries_once_on_401_with_stale_metadata(self):
+        client = self.make_client()
+        client._token_expires_at = datetime.now() + timedelta(hours=4)
+
+        responses = [
+            self.http_error(401, "Unauthorized"),
+            FakeResponse({"ok": True}),
+        ]
+
+        def fake_urlopen(req, timeout=10):
+            next_item = responses.pop(0)
+            if isinstance(next_item, Exception):
+                raise next_item
+            return next_item
+
+        with mock.patch.object(client, "refresh_access_token", return_value=True) as refresh_mock:
+            with mock.patch.object(fitbit_api.urllib.request, "urlopen", side_effect=fake_urlopen):
+                response = client._request("1/user/-/activities/date/2026-03-14.json")
+
+        self.assertEqual(response, {"ok": True})
+        refresh_mock.assert_called_once_with(force=True)
+
+    def test_refresh_access_token_raises_reauth_error_for_invalid_grant(self):
+        client = self.make_client()
+        client._save_tokens("old_access", "old_refresh", 3600)
+        before_secrets = self.secrets_path.read_text(encoding="utf-8")
+        before_cache = self.cache_path.read_text(encoding="utf-8")
+
+        error = self.http_error(
+            400,
+            "Bad Request",
+            {"errors": [{"errorType": "invalid_grant", "message": "Refresh token invalid"}]},
+        )
+
+        with mock.patch.object(fitbit_api.urllib.request, "urlopen", side_effect=error):
+            with self.assertRaises(fitbit_api.FitbitReauthRequiredError):
+                client.refresh_access_token(force=True)
+
+        self.assertEqual(self.secrets_path.read_text(encoding="utf-8"), before_secrets)
+        self.assertEqual(self.cache_path.read_text(encoding="utf-8"), before_cache)
+
+    def test_refresh_access_token_retries_transient_network_errors_without_mutating_tokens(self):
+        client = self.make_client()
+        client._save_tokens("old_access", "old_refresh", 3600)
+        before_secrets = self.secrets_path.read_text(encoding="utf-8")
+        before_cache = self.cache_path.read_text(encoding="utf-8")
+
+        with mock.patch.object(
+            fitbit_api.urllib.request,
+            "urlopen",
+            side_effect=urllib.error.URLError("network down"),
+        ) as urlopen_mock:
+            with mock.patch.object(fitbit_api.time, "sleep") as sleep_mock:
+                with self.assertRaises(fitbit_api.FitbitAuthError):
+                    client.refresh_access_token(force=True)
+
+        self.assertEqual(urlopen_mock.call_count, len(client.REFRESH_RETRY_DELAYS_SECONDS))
+        self.assertEqual(sleep_mock.call_count, len(client.REFRESH_RETRY_DELAYS_SECONDS) - 1)
+        self.assertEqual(self.secrets_path.read_text(encoding="utf-8"), before_secrets)
+        self.assertEqual(self.cache_path.read_text(encoding="utf-8"), before_cache)
+
+    def test_refresh_access_token_waits_for_lock_before_refreshing(self):
+        client = self.make_client()
+        release_lock = threading.Event()
+        refresh_finished = threading.Event()
+
+        def hold_lock():
+            with client._token_lock():
+                release_lock.wait(timeout=2)
+
+        holder = threading.Thread(target=hold_lock)
+        holder.start()
+        pytime.sleep(0.1)
+
+        def refresh_in_thread():
+            try:
+                client.refresh_access_token(force=True)
+            finally:
+                refresh_finished.set()
+
+        refresher = threading.Thread(target=refresh_in_thread)
+        with mock.patch.object(
+            fitbit_api.urllib.request,
+            "urlopen",
+            return_value=FakeResponse(
+                {
+                    "access_token": "new_access",
+                    "refresh_token": "new_refresh",
+                    "expires_in": 3600,
+                }
+            ),
+        ):
+            refresher.start()
+            pytime.sleep(0.1)
+            self.assertFalse(refresh_finished.is_set())
+            release_lock.set()
+            refresher.join(timeout=2)
+
+        holder.join(timeout=2)
+        self.assertTrue(refresh_finished.is_set())
+
+    def test_refresh_cli_skips_when_tokens_are_current(self):
+        fake_client = mock.Mock()
+        fake_client.refresh_access_token.return_value = False
+
+        stderr = io.StringIO()
+        with mock.patch.object(refresh_tokens, "FitbitClient", return_value=fake_client):
+            with redirect_stderr(stderr):
+                exit_code = refresh_tokens.main([])
+
+        self.assertEqual(exit_code, 0)
+        fake_client.refresh_access_token.assert_called_once_with(force=False, max_age_hours=6)
+        self.assertIn("refresh skipped", stderr.getvalue())
+
+    def test_refresh_cli_refreshes_when_due(self):
+        fake_client = mock.Mock()
+        fake_client.refresh_access_token.return_value = True
+
+        stderr = io.StringIO()
+        with mock.patch.object(refresh_tokens, "FitbitClient", return_value=fake_client):
+            with redirect_stderr(stderr):
+                exit_code = refresh_tokens.main(["--max-age-hours", "8"])
+
+        self.assertEqual(exit_code, 0)
+        fake_client.refresh_access_token.assert_called_once_with(force=False, max_age_hours=8)
+        self.assertIn("tokens refreshed", stderr.getvalue().lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fitbit_auth.py
+++ b/tests/test_fitbit_auth.py
@@ -107,6 +107,20 @@ class FitbitAuthTests(unittest.TestCase):
         self.assertEqual(client._access_token, "old_access")
         self.assertEqual(client._refresh_token, "old_refresh")
 
+    def test_blank_environment_tokens_fall_back_to_secrets(self):
+        with mock.patch.dict(
+            fitbit_api.os.environ,
+            {
+                "FITBIT_ACCESS_TOKEN": "",
+                "FITBIT_REFRESH_TOKEN": "",
+            },
+            clear=False,
+        ):
+            client = self.make_client()
+
+        self.assertEqual(client._access_token, "old_access")
+        self.assertEqual(client._refresh_token, "old_refresh")
+
     def test_request_refreshes_before_api_call_when_token_is_near_expiry(self):
         client = self.make_client()
         client._token_expires_at = datetime.now() + timedelta(minutes=30)
@@ -259,6 +273,22 @@ class FitbitAuthTests(unittest.TestCase):
         self.assertTrue(refreshed)
         self.assertEqual(client._access_token, "rotated_access")
         self.assertEqual(client._refresh_token, "rotated_refresh")
+
+    def test_save_tokens_updates_export_assignments_in_place(self):
+        self.secrets_path.write_text(
+            'export FITBIT_ACCESS_TOKEN="old_access"\n'
+            'export FITBIT_REFRESH_TOKEN="old_refresh"\n',
+            encoding="utf-8",
+        )
+        client = self.make_client()
+
+        client._save_tokens("new_access", "new_refresh", 3600)
+
+        secrets_content = self.secrets_path.read_text(encoding="utf-8")
+        self.assertEqual(secrets_content.count("FITBIT_ACCESS_TOKEN"), 1)
+        self.assertEqual(secrets_content.count("FITBIT_REFRESH_TOKEN"), 1)
+        self.assertIn('export FITBIT_ACCESS_TOKEN="new_access"', secrets_content)
+        self.assertIn('export FITBIT_REFRESH_TOKEN="new_refresh"', secrets_content)
 
     def test_refresh_access_token_waits_for_lock_before_refreshing(self):
         client = self.make_client()

--- a/tests/test_fitbit_auth.py
+++ b/tests/test_fitbit_auth.py
@@ -143,6 +143,25 @@ class FitbitAuthTests(unittest.TestCase):
         self.assertEqual(response, {"ok": True})
         refresh_mock.assert_not_called()
 
+    def test_request_continues_when_preflight_refresh_fails(self):
+        client = self.make_client()
+        client._token_expires_at = datetime.now() + timedelta(minutes=30)
+
+        with mock.patch.object(
+            client,
+            "refresh_access_token",
+            side_effect=fitbit_api.FitbitAuthError("temporary refresh failure"),
+        ) as refresh_mock:
+            with mock.patch.object(
+                fitbit_api.urllib.request,
+                "urlopen",
+                return_value=FakeResponse({"ok": True}),
+            ):
+                response = client._request("1/user/-/profile.json")
+
+        self.assertEqual(response, {"ok": True})
+        refresh_mock.assert_called_once_with()
+
     def test_request_retries_once_on_401_with_stale_metadata(self):
         client = self.make_client()
         client._token_expires_at = datetime.now() + timedelta(hours=4)


### PR DESCRIPTION
## Summary
- harden Fitbit token persistence and refresh handling
- add proactive refresh CLI and stdlib regression tests
- update setup and skill docs for the new refresh flow

Closes #20
Closes #21